### PR TITLE
Bugfix/23 navigation title scroll shrink

### DIFF
--- a/SoccerInfo/Views/Schedules/Fixtures/FixturesViewController.swift
+++ b/SoccerInfo/Views/Schedules/Fixtures/FixturesViewController.swift
@@ -85,7 +85,7 @@ final class FixturesViewController: BasicTabViewController<FixturesRealmData> {
         schedulesTableView.dataSource = self
         schedulesTableView.backgroundColor = .clear
         schedulesTableView.separatorInset.right = schedulesTableView.separatorInset.left
-        view.addSubview(schedulesTableView)
+        addSubviews(schedulesTableView)
         
         // Swipe Gesture for change monday of week
         let leftSwipeGesture = UISwipeGestureRecognizer(target: self,

--- a/SoccerInfo/Views/SuperClasses/BasicTabViewController.swift
+++ b/SoccerInfo/Views/SuperClasses/BasicTabViewController.swift
@@ -37,9 +37,6 @@ class BasicTabViewController<T: BasicTabViewData>: UIViewController, UINavigatio
     func viewConfig() {
         changeBackgroundColor()
         
-        // activity view config
-        activityView = activityIndicator()
-        
         // gradient config
         gradient.frame = view.bounds
         gradient.startPoint = CGPoint(x: 0.5, y: 0.7)
@@ -48,6 +45,11 @@ class BasicTabViewController<T: BasicTabViewData>: UIViewController, UINavigatio
         view.layer.insertSublayer(gradient, at: 0)
         
         navAppearenceConfig()
+    }
+    
+    func addSubviews(_ subviews: UIView...) {
+        subviews.forEach { view.addSubview($0) }        
+        activityView = activityIndicator()
     }
     
     func constraintsConfig() { }


### PR DESCRIPTION
테이블뷰의 서브뷰 순서 문제였으며 맨첫번째로 들어가야 제대로 동작함
BasicTabViewController에 addSubviews 메서드를 추가
addSubviews: 모든 서브뷰 추가 후에 맨 마지막에 Indicator를 서브뷰로 추가하도록 설정

스토리보드를 이용했을때는 모든 서브뷰가 스토리보드를 통해 이미 추가됐었고
그 후에 Indicator가 코드로 추가됐어서 제대로 동작했었음